### PR TITLE
Use submission state instead of submitted time

### DIFF
--- a/easy_run.py
+++ b/easy_run.py
@@ -159,7 +159,7 @@ def transfer_assignments_to_todoist():
             # print(assignment)
 
         if not is_added:
-            if assignment['submission']['submitted_at'] == None:
+            if (assignment['submission']['workflow_state'] == "unsubmitted"):
                 print("Adding assignment " + assignment['name'])
                 add_new_task(assignment, project_id)
             else:


### PR DESCRIPTION
There is currently a bug where when there is an assignment of type where user cannot submit and the instructor has made a submission in for the student, the script keeps re-adding the assignment every time the script is run if the task is already checked off.

An alternative to see the status of a submission is to look at the workflow state of the submission:
https://canvas.instructure.com/doc/api/submissions.html#method.submissions_api.index
