### PR TITLE
Rest api migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,11 @@ share/python-wheels/
 *.egg
 MANIFEST
 
+# Pyvenv stuff
+pyvenv.cfg
+Scripts/
+*.txt
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ MANIFEST
 # Pyvenv stuff
 pyvenv.cfg
 Scripts/
-*.txt
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
-	"todoist_api_key": "", 
-	"canvas_api_key": "", 
-	"canvas_api_heading": "https://canvas.instructure.com", 
+	"todoist_api_key": "",
+	"canvas_api_key": "",
+	"canvas_api_heading": "https://canvas.instructure.com",
 	"courses": []
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ certifi>=2021.5.30
 chardet>=4.0.0
 idna>=2.10
 requests==2.27.1
-todoist-python==8.1.3
+todoist-api-python==2.0.2
 urllib3==1.26.8


### PR DESCRIPTION
api_keys.txt is no longer tracked by using
```git update-index --assume-unchanged [path]```

Ran the script without any hiccups, but need to test further as code coverage is not the best atm